### PR TITLE
Fix Webkit text rendering

### DIFF
--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -43,7 +43,7 @@ export type TextData = {
     "font-weight"      : string,
     "font-style"       : string,
     "text-anchor"      : string,
-    "dominant-baseline": string,
+    "dy"               : string, // used to be "dominant-baseline": string,
     "angle"            : string,
     "font-scale"       : string, // this is a custom attribute that is not present in SVG
     // "letter-spacing"   : string,
@@ -61,15 +61,15 @@ function anchor_to_textdata(anchor : Anchor) : Partial<TextData> {
     // hanging vs text-before-edge
     // ideographic vs text-after-edge
     switch (anchor) {
-        case "top-left"      : return {"text-anchor" : "start" , "dominant-baseline" : "text-before-edge"};
-        case "top-center"    : return {"text-anchor" : "middle", "dominant-baseline" : "text-before-edge"};
-        case "top-right"     : return {"text-anchor" : "end"   , "dominant-baseline" : "text-before-edge"};
-        case "center-left"   : return {"text-anchor" : "start" , "dominant-baseline" : "middle"};
-        case "center-center" : return {"text-anchor" : "middle", "dominant-baseline" : "middle"};
-        case "center-right"  : return {"text-anchor" : "end"   , "dominant-baseline" : "middle"};
-        case "bottom-left"   : return {"text-anchor" : "start" , "dominant-baseline" : "text-after-edge"};
-        case "bottom-center" : return {"text-anchor" : "middle", "dominant-baseline" : "text-after-edge"};
-        case "bottom-right"  : return {"text-anchor" : "end"   , "dominant-baseline" : "text-after-edge"};
+        case "top-left"      : return {"text-anchor" : "start" , "dy" : "0.75em"};
+        case "top-center"    : return {"text-anchor" : "middle", "dy" : "0.75em"};
+        case "top-right"     : return {"text-anchor" : "end"   , "dy" : "0.75em"};
+        case "center-left"   : return {"text-anchor" : "start" , "dy" : "0.25em"};
+        case "center-center" : return {"text-anchor" : "middle", "dy" : "0.25em"};
+        case "center-right"  : return {"text-anchor" : "end"   , "dy" : "0.25em"};
+        case "bottom-left"   : return {"text-anchor" : "start" , "dy" : "-0.25em"};
+        case "bottom-center" : return {"text-anchor" : "middle", "dy" : "-0.25em"};
+        case "bottom-right"  : return {"text-anchor" : "end"   , "dy" : "-0.25em"};
         default: throw new Error("Unknown anchor " + anchor);
     }
 }
@@ -379,8 +379,8 @@ export class Diagram {
     public textanchor(textanchor : 'start' | 'middle' | 'end' ) : Diagram {
         return this.update_textdata('text-anchor', textanchor);
     }
-    public textdominantbaseline(dominantbaseline : 'auto' | 'text-bottom' | 'alphabetic' | 'ideographic' | 'middle' | 'central' | 'mathematical' | 'hanging' | 'text-top' ) : Diagram {
-        return this.update_textdata('dominant-baseline', dominantbaseline);
+    public textdy(dy : string) : Diagram {
+        return this.update_textdata('dy', dy);
     }
     public textangle(angle : number){
         return this.update_textdata('angle', angle.toString());
@@ -643,7 +643,7 @@ export class Diagram {
         let newd = this.copy_if_not_mutable();
         let textdata = anchor_to_textdata(anchor);
         newd.textdata['text-anchor'] = textdata['text-anchor'];
-        newd.textdata['dominant-baseline'] = textdata['dominant-baseline'];
+        newd.textdata['dy'] = textdata['dy'];
         return newd;
     }
 

--- a/src/draw_svg.ts
+++ b/src/draw_svg.ts
@@ -39,7 +39,7 @@ export const default_textdata : TextData = {
     "font-size"        : "18",
     "font-weight"      : "normal",
     "text-anchor"      : "middle",
-    "dominant-baseline": "middle",
+    "dy"               : "0",
     "angle"            : "0",
     "font-style"       : "normal",
     "font-scale"       : "auto",
@@ -231,7 +231,8 @@ function draw_texts(svgelement : SVGSVGElement, diagrams : Diagram[],
         text.setAttribute("font-size", font_size.toString());
         text.setAttribute("font-weight", textdata["font-weight"] as string);
         text.setAttribute("text-anchor", textdata["text-anchor"] as string);
-        text.setAttribute("dominant-baseline", textdata["dominant-baseline"] as string);
+        text.setAttribute("dy", textdata["dy"] as string);
+        // text.setAttribute("dominant-baseline", textdata["dominant-baseline"] as string);
         text.setAttribute("transform", `translate(${xpos} ${ypos}) rotate(${angle_deg}) `);
         if (svgtag != undefined) text.setAttribute("_dg_tag", svgtag);
 


### PR DESCRIPTION
Vertical text anchor is now described using `dy` instead of [`dominant-baseline`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dominant-baseline). 

Webkit has some compatibility issues regarding the implementation of `dominant-baseline`
( [https://stackoverflow.com/questions/35565063/svg-dominant-baseline-not-working-in-safari](https://stackoverflow.com/questions/35565063/svg-dominant-baseline-not-working-in-safari)  )

The issue only occurs in small SVGs. (*which can also appear in a scaled-up version of those small SVG)

The image below shows how it look before the fix (left : Chromium, right : apple's WebKit (epiphany browser))
![buggy](https://github.com/ray-pH/diagramatics/assets/57003984/40678963-2797-4fbd-add4-f863d8ded71d)


And here's after the fix
![fixed](https://github.com/ray-pH/diagramatics/assets/57003984/beece43f-6e68-43a8-8c33-58b6c2c0a8d6)


Fix #7 